### PR TITLE
Fix for issue #1, Crash with non-0 offset

### DIFF
--- a/Mmap.xs
+++ b/Mmap.xs
@@ -224,12 +224,13 @@ mmap(var, len, prot, flags, fh = 0, off_string)
 	if (!(prot & PROT_WRITE))
 	    SvREADONLY_on(var);
 
-        /* would sv_usepvn() be cleaner/better/different? would still try to realloc... */
-	SvPVX(var) = (char *) addr + slop;
-	SvCUR_set(var, len);
-	SvLEN_set(var, slop);
+	SvPVX(var) = (char *) addr;
+	SvCUR_set(var, len + slop);
+	if (slop > 0) {
+		sv_chop(var, addr + slop);
+	}
 	SvPOK_only(var);
-        ST(0) = sv_2mortal(newSVnv((IV) addr));
+		ST(0) = sv_2mortal(newSViv((IV) addr));
 
 SV *
 munmap(var)

--- a/t/mmap.t
+++ b/t/mmap.t
@@ -3,7 +3,7 @@
 BEGIN {
     use strict;
     use warnings;
-    use Test::More tests => 8;
+    use Test::More tests => 9;
 
     use_ok('Sys::Mmap');
 }
@@ -36,6 +36,12 @@ close FOO;
 substr($foo, 3, 1) = "Z";
 substr($temp_file_contents, 3, 1) = "Z";
 is($foo, $temp_file_contents, 'Foo can be altered in RW mode');
+munmap($foo);
+
+sysopen(FOO, $temp_file, O_RDWR) or die "$temp_file: $!\n";
+mmap($foo, 0, PROT_READ|PROT_WRITE, MAP_SHARED, FOO, 5);
+close FOO;
+is(substr($foo, 5, 1), '2', 'Offset handled');
 munmap($foo);
 
 sysopen(FOO, $temp_file, O_RDONLY) or die "$temp_file: $!\n";

--- a/t/on_exit.t
+++ b/t/on_exit.t
@@ -1,0 +1,26 @@
+#! perl
+
+BEGIN {
+    use strict;
+    use warnings;
+    use Test::More tests => 1;
+
+    use_ok('Sys::Mmap');
+}
+
+use FileHandle;
+
+my $temp_file = "mmap.tmp";
+
+my $temp_file_contents = "0" x 1000; 
+sysopen(FOO, $temp_file, O_WRONLY|O_CREAT|O_TRUNC) or die "$temp_file: $!\n";
+print FOO $temp_file_contents;
+close FOO;
+
+# Perl was segfaulting when exiting after using a non zero offset
+# The key here is that munmap was not done before exiting
+my $foo;
+sysopen(FOO, $temp_file, O_RDWR) or die "$temp_file: $!\n";
+mmap($foo, 0, PROT_READ, MAP_SHARED, FOO, 256);
+
+unlink($temp_file);


### PR DESCRIPTION
Use sv_chop to set up offset hack when the offset is not aligned with the page size
Changed newSVnv to newSViv because the signature matches the argument being passed.

This is part of the 2016 Pull Request Challenge.
