### PR TITLE
update gpl text to current

### DIFF
--- a/Copying
+++ b/Copying
@@ -1,12 +1,14 @@
-		    GNU GENERAL PUBLIC LICENSE
-		     Version 1, February 1989
+
+                    GNU GENERAL PUBLIC LICENSE
+                     Version 1, February 1989
 
  Copyright (C) 1989 Free Software Foundation, Inc.
-                    675 Mass Ave, Cambridge, MA 02139, USA
+                    51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
-			    Preamble
+                            Preamble
 
   The license agreements of most software companies try to keep users
 at the mercy of those companies.  By contrast, our General Public
@@ -46,8 +48,8 @@ authors' reputations.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
-
-		    GNU GENERAL PUBLIC LICENSE
+
+                    GNU GENERAL PUBLIC LICENSE
    TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
   0. This License Agreement applies to any program or other work which
@@ -97,7 +99,7 @@ it, and copy and distribute such modifications under the terms of Paragraph
 Mere aggregation of another independent work with the Program (or its
 derivative) on a volume of a storage or distribution medium does not bring
 the other work under the scope of these terms.
-
+
   3. You may copy and distribute the Program (or a portion or derivative of
 it, under Paragraph 2) in object code or executable form under the terms of
 Paragraphs 1 and 2 above provided that you also do one of the following:
@@ -143,7 +145,7 @@ Program), the recipient automatically receives a license from the original
 licensor to copy, distribute or modify the Program subject to these
 terms and conditions.  You may not impose any further restrictions on the
 recipients' exercise of the rights granted herein.
-
+
   7. The Free Software Foundation may publish revised and/or new versions
 of the General Public License from time to time.  Such new versions will
 be similar in spirit to the present version, but may differ in detail to
@@ -165,7 +167,7 @@ make exceptions for this.  Our decision will be guided by the two goals
 of preserving the free status of all derivatives of our free software and
 of promoting the sharing and reuse of software generally.
 
-			    NO WARRANTY
+                            NO WARRANTY
 
   9. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
 FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
@@ -187,9 +189,9 @@ YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
 PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGES.
 
-		     END OF TERMS AND CONDITIONS
-
-	Appendix: How to Apply These Terms to Your New Programs
+                     END OF TERMS AND CONDITIONS
+
+        Appendix: How to Apply These Terms to Your New Programs
 
   If you develop a new program, and you want it to be of the greatest
 possible use to humanity, the best way to achieve this is to make it
@@ -216,7 +218,8 @@ the exclusion of warranty; and each file should have at least the
 
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
-    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston MA  02110-1301 USA
+
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -246,3 +249,4 @@ necessary.  Here a sample; alter the names:
   Ty Coon, President of Vice
 
 That's all there is to it!
+

--- a/README
+++ b/README
@@ -22,7 +22,7 @@
     distribution. You should also have received a copy of the GNU General
     Public License, in the file named "Copying". If not, you can get one
     from the Perl distribution or else write to the Free Software
-    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA.
 
 DESCRIPTION
 


### PR DESCRIPTION
This PR updates gpl license to the current one found here:
https://www.gnu.org/licenses/old-licenses/gpl-1.0.txt

Basically, the US mailing address changed since the time the license was first written.

This minor change gets rpmlint/lintian packaging tools to stop complaining the license is not correct:

```
$ rpmlint perl-Sys-Mmap-0.18-1.fc26.x86_64.rpm
perl-Sys-Mmap.x86_64: E: incorrect-fsf-address /usr/share/licenses/perl-Sys-Mmap/Copying
1 packages and 0 specfiles checked; 1 errors, 0 warnings.
```
