### PR TITLE
Spelling error in manpage

### DIFF
--- a/Mmap.pm
+++ b/Mmap.pm
@@ -156,7 +156,7 @@ There should be a tied interface to C<hardwire()> as well.
 
 Scott Walter's spelling is awful.
 
-C<hardwire()> will segfault Perl if the C<mmap()> area it was refering to is
+C<hardwire()> will segfault Perl if the C<mmap()> area it was referring to is
 C<munmap()>'d out from under it.
 
 C<munmap()> will segfault Perl if the variable was not successfully C<mmap()>'d


### PR DESCRIPTION

Hi

In Debian we are currently applying the following patch to Sys-Mmap.
We thought you might be interested in it too.

    Description: Spelling error in manpage
    Origin: vendor
    Author: Salvatore Bonaccorso <carnil@debian.org>
    Last-Update: 2017-11-12
    

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libsys-mmap-perl.git/plain/debian/patches/spelling-error-in-manpage.patch

Thanks for considering,
  Salvatore Bonaccorso,
  Debian Perl Group
